### PR TITLE
Switch password hashing to Argon2

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,5 +2,5 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.1   # сервер для запуска
 sqlalchemy==2.0.31          # ORM
 pydantic==2.8.2             # схемы данных
-passlib[bcrypt]==1.7.4      # хэширование паролей
+passlib[argon2]==1.7.4      # хэширование паролей
 python-multipart==0.0.9     # TODO: понадобится для загрузки файлов (например, аватарки)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from database import SessionLocal
 from models import User
 from schemas import UserCreate, UserLogin, UserOut
-from passlib.hash import bcrypt
+from passlib.hash import argon2
 
 router = APIRouter()
 
@@ -19,7 +19,7 @@ def register(user: UserCreate, db: Session = Depends(get_db)):
     db_user = db.query(User).filter(User.email == user.email).first()
     if db_user:
         raise HTTPException(status_code=400, detail="Email уже зарегистрирован")
-    hashed_pw = bcrypt.hash(user.password)
+    hashed_pw = argon2.hash(user.password)
     new_user = User(name=user.name, email=user.email, hashed_password=hashed_pw)
     db.add(new_user)
     db.commit()
@@ -29,7 +29,7 @@ def register(user: UserCreate, db: Session = Depends(get_db)):
 @router.post("/login", response_model=UserOut)
 def login(user: UserLogin, db: Session = Depends(get_db)):
     db_user = db.query(User).filter(User.email == user.email).first()
-    if not db_user or not bcrypt.verify(user.password, db_user.hashed_password):
+    if not db_user or not argon2.verify(user.password, db_user.hashed_password):
         raise HTTPException(status_code=401, detail="Неверные учетные данные")
     return db_user
 


### PR DESCRIPTION
## Summary
- replace bcrypt password hashing with Argon2 in the authentication router
- update backend dependencies to include the Argon2 backend for passlib

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ded4b6214883328d606df2ac0b1898