### PR TITLE
Show logged-in avatar on hero section

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,9 +2,16 @@ import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowDown } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
+type HeroSectionProps = {
+  user?: {
+    name?: string;
+    avatar?: string;
+  } | null;
+};
 
-const HeroSection = () => {
+const HeroSection = ({ user }: HeroSectionProps) => {
   const [isVideoAvailable, setIsVideoAvailable] = useState(true);
   const navigate = useNavigate();
 
@@ -71,13 +78,33 @@ const HeroSection = () => {
 
       {/* Login Button */}
       <div className="absolute top-8 right-8 z-20">
-        <Button 
-          variant="ghost"
-          onClick={() => navigate("/login")}
-          className="text-white/80 hover:text-white hover:bg-white/10 border border-white/20 hover:border-white/40 backdrop-blur-sm"
-        >
-          Войти
-        </Button>
+        {user ? (
+          <button
+            type="button"
+            onClick={() => navigate("/dashboard")}
+            className="flex items-center justify-center rounded-full border border-white/30 bg-white/10 p-0.5 transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            aria-label="Перейти в личный кабинет"
+          >
+            <Avatar className="h-11 w-11 border border-white/30">
+              <AvatarImage
+                src={user.avatar}
+                alt={user.name}
+                className="object-cover"
+              />
+              <AvatarFallback className="bg-navy text-white text-sm font-medium">
+                {user.name?.[0]?.toUpperCase() ?? "?"}
+              </AvatarFallback>
+            </Avatar>
+          </button>
+        ) : (
+          <Button
+            variant="ghost"
+            onClick={() => navigate("/login")}
+            className="text-white/80 hover:text-white hover:bg-white/10 border border-white/20 hover:border-white/40 backdrop-blur-sm"
+          >
+            Войти
+          </Button>
+        )}
       </div>
 
       {/* Scroll Indicator */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import HeroSection from "@/components/HeroSection";
 import MarqueeSection from "@/components/MarqueeSection";
 import AboutSection from "@/components/AboutSection";
@@ -12,10 +13,54 @@ import FAQSection from "@/components/FAQSection";
 import ContactFormSection from "@/components/ContactFormSection";
 import Footer from "@/components/Footer";
 
+type User = {
+  id: number;
+  name: string;
+  avatar: string;
+};
+
 const Index = () => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const userId = window.localStorage.getItem("userId");
+    if (!userId) {
+      setUser(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    fetch(`http://localhost:8000/users/${userId}`)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("Failed to fetch user");
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (isMounted) {
+          setUser(data);
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setUser(null);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <div className="min-h-screen">
-      <HeroSection />
+      <HeroSection user={user ?? undefined} />
       <MarqueeSection />
       <AboutSection />
       <WhyUsSection />


### PR DESCRIPTION
## Summary
- fetch the logged-in user when loading the landing page and pass the data to the hero section
- replace the hero login button with the user avatar that links to the dashboard when authenticated

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68ded7d37408833289d8ee6487cbee6b