### PR TITLE
Add backend support for contact form submissions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import auth, users, courses
+from routers import auth, users, courses, contact_requests
 from database import Base, engine
 
 # Создание таблиц
@@ -11,7 +11,7 @@ app = FastAPI(title="Courseborn API")
 # Разрешаем CORS для фронта
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:8080"],  # фронт у тебя на 8080
+    allow_origins=["http://localhost:8080", "http://localhost:5173"],  # фронт
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -21,6 +21,7 @@ app.add_middleware(
 app.include_router(auth.router, prefix="/auth", tags=["Auth"])
 app.include_router(users.router, prefix="/users", tags=["Users"])
 app.include_router(courses.router, prefix="/courses", tags=["Courses"])
+app.include_router(contact_requests.router, prefix="/contact-requests", tags=["Contact Requests"])
 
 @app.get("/")
 def root():

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, func
 from database import Base
 
 class User(Base):
@@ -10,3 +10,18 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
 
 # TODO: позже добавить модель Course, если будем хранить курсы в БД
+
+
+class ContactRequest(Base):
+    __tablename__ = "contact_requests"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    email = Column(String, nullable=False)
+    phone = Column(String, nullable=False)
+    course = Column(String, nullable=False)
+    message = Column(Text, default="")
+    personal_data_consent = Column(Boolean, nullable=False, default=False)
+    terms_consent = Column(Boolean, nullable=False, default=False)
+    marketing_consent = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/routers/contact_requests.py
+++ b/backend/routers/contact_requests.py
@@ -1,0 +1,39 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from database import SessionLocal
+from models import ContactRequest
+from schemas import ContactRequestCreate, ContactRequestOut
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("", response_model=ContactRequestOut, status_code=status.HTTP_201_CREATED)
+def create_contact_request(payload: ContactRequestCreate, db: Session = Depends(get_db)):
+    contact_request = ContactRequest(**payload.dict())
+
+    try:
+        db.add(contact_request)
+        db.commit()
+        db.refresh(contact_request)
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Не удалось сохранить заявку") from exc
+
+    return contact_request
+
+
+@router.get("", response_model=List[ContactRequestOut])
+def list_contact_requests(db: Session = Depends(get_db)):
+    return db.query(ContactRequest).order_by(ContactRequest.created_at.desc()).all()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 class UserCreate(BaseModel):
@@ -18,3 +19,26 @@ class UserOut(BaseModel):
         orm_mode = True
 
 # TODO: добавить схемы для Course, когда будем хранить в БД
+
+
+class ContactRequestBase(BaseModel):
+    name: str
+    email: str
+    phone: str
+    course: str
+    message: str | None = None
+    personal_data_consent: bool
+    terms_consent: bool
+    marketing_consent: bool = False
+
+
+class ContactRequestCreate(ContactRequestBase):
+    pass
+
+
+class ContactRequestOut(ContactRequestBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add a ContactRequest model, schema, and router to persist contact form submissions
- register the contact request API and extend CORS configuration for local frontends
- connect the contact form UI to the backend endpoint and require consent checkboxes before submission

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68dedc7708d48332964c0ff829c14869