### PR TITLE
feat: add dashboard course video player experience

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,15 @@
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, func
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.orm import relationship
+
 from database import Base
 
 class User(Base):
@@ -9,7 +20,38 @@ class User(Base):
     avatar = Column(String, default="")
     hashed_password = Column(String, nullable=False)
 
-# TODO: позже добавить модель Course, если будем хранить курсы в БД
+class Course(Base):
+    __tablename__ = "courses"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    description = Column(Text, default="")
+    progress = Column(Integer, nullable=False, default=0)
+    thumbnail = Column(String, default="")
+
+    lessons = relationship(
+        "Lesson",
+        back_populates="course",
+        cascade="all, delete-orphan",
+        order_by="Lesson.order",
+    )
+
+
+class Lesson(Base):
+    __tablename__ = "lessons"
+
+    id = Column(Integer, primary_key=True, index=True)
+    course_id = Column(
+        Integer,
+        ForeignKey("courses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title = Column(String, nullable=False)
+    video_url = Column(String, nullable=False)
+    order = Column(Integer, nullable=False, default=0)
+
+    course = relationship("Course", back_populates="lessons")
 
 
 class ContactRequest(Base):

--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -1,14 +1,117 @@
-from fastapi import APIRouter
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session, selectinload
+
+from database import SessionLocal
+from models import Course, Lesson
+from schemas import CourseDetail, CourseListItem
 
 router = APIRouter()
 
-# TODO: вынести в БД, сейчас mock
-courses = [
-    {"id": 1, "title": "Основы Python", "progress": 70},
-    {"id": 2, "title": "Веб-разработка с Django", "progress": 40},
-    {"id": 3, "title": "Разработка Telegram-ботов", "progress": 15},
-]
 
-@router.get("/")
-def get_courses():
-    return courses
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def seed_courses(db: Session) -> None:
+    """Создаём демо-курсы, если база пуста."""
+
+    if db.query(Course).count():
+        return
+
+    demo_courses = [
+        {
+            "title": "Основы Python",
+            "description": "Изучите базовый синтаксис Python и напишите свои первые программы.",
+            "progress": 70,
+            "thumbnail": "https://images.unsplash.com/photo-1582719478173-2cf4e1e7ed49?auto=format&fit=crop&w=400&q=80",
+            "lessons": [
+                {
+                    "title": "Введение в Python",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-mountain-road-2133/1080p.mp4",
+                },
+                {
+                    "title": "Переменные и типы данных",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-typing-on-a-laptop-7327/1080p.mp4",
+                },
+                {
+                    "title": "Условия и циклы",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-downtown-street-3068/1080p.mp4",
+                },
+            ],
+        },
+        {
+            "title": "Веб-разработка с Django",
+            "description": "Постройте полноценное веб-приложение на Django шаг за шагом.",
+            "progress": 40,
+            "thumbnail": "https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=400&q=80",
+            "lessons": [
+                {
+                    "title": "Знакомство с Django",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-coding-on-the-move-6133/1080p.mp4",
+                },
+                {
+                    "title": "Модели и миграции",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-working-at-the-office-1920/1080p.mp4",
+                },
+                {
+                    "title": "Создание шаблонов",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-man-working-on-his-laptop-at-a-cafe-6103/1080p.mp4",
+                },
+            ],
+        },
+        {
+            "title": "Разработка Telegram-ботов",
+            "description": "Узнайте, как создавать полезных Telegram-ботов на Python.",
+            "progress": 15,
+            "thumbnail": "https://images.unsplash.com/photo-1556740749-887f6717d7e4?auto=format&fit=crop&w=400&q=80",
+            "lessons": [
+                {
+                    "title": "Регистрация бота и первые шаги",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-working-on-a-laptop-4104/1080p.mp4",
+                },
+                {
+                    "title": "Обработка сообщений",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-the-future-is-here-5985/1080p.mp4",
+                },
+                {
+                    "title": "Подключение внешних API",
+                    "video_url": "https://cdn.coverr.co/videos/coverr-a-man-typing-on-a-laptop-7688/1080p.mp4",
+                },
+            ],
+        },
+    ]
+
+    for course_index, course_data in enumerate(demo_courses, start=1):
+        lessons_data = course_data.pop("lessons", [])
+        course = Course(id=course_index, **course_data)
+        for order, lesson_data in enumerate(lessons_data, start=1):
+            course.lessons.append(Lesson(order=order, **lesson_data))
+        db.add(course)
+
+    db.commit()
+
+
+@router.get("/", response_model=List[CourseListItem])
+def get_courses(db: Session = Depends(get_db)):
+    seed_courses(db)
+    return db.query(Course).order_by(Course.id).all()
+
+
+@router.get("/{course_id}", response_model=CourseDetail)
+def get_course(course_id: int, db: Session = Depends(get_db)):
+    seed_courses(db)
+    course = (
+        db.query(Course)
+        .options(selectinload(Course.lessons))
+        .filter(Course.id == course_id)
+        .first()
+    )
+    if course is None:
+        raise HTTPException(status_code=404, detail="Курс не найден")
+    return course

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from pydantic import BaseModel
+from typing import List
+
+from pydantic import BaseModel, Field, HttpUrl
 
 class UserCreate(BaseModel):
     name: str
@@ -18,7 +20,33 @@ class UserOut(BaseModel):
     class Config:
         orm_mode = True
 
-# TODO: добавить схемы для Course, когда будем хранить в БД
+class LessonOut(BaseModel):
+    id: int
+    title: str
+    video_url: HttpUrl
+    order: int = Field(0, description="Порядок урока в курсе")
+
+    class Config:
+        orm_mode = True
+
+
+class CourseBase(BaseModel):
+    id: int
+    title: str
+    description: str | None = ""
+    progress: int = 0
+    thumbnail: str | None = None
+
+    class Config:
+        orm_mode = True
+
+
+class CourseListItem(CourseBase):
+    pass
+
+
+class CourseDetail(CourseBase):
+    lessons: List[LessonOut]
 
 
 class ContactRequestBase(BaseModel):

--- a/src/pages/dashboard/sections/CoursesSection.tsx
+++ b/src/pages/dashboard/sections/CoursesSection.tsx
@@ -1,65 +1,359 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Card, CardContent } from "@/components/ui/card";
+
+import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { Button } from "@/components/ui/button";
-import {useEffect, useState} from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
-export default function CoursesSection({ theme }) {
-  const [courses, setCourses] = useState([]);
+type CoursesSectionProps = {
+  theme: string;
+};
 
-useEffect(() => {
-  fetch("http://localhost:8000/courses")
-    .then(res => res.json())
-    .then(data => setCourses(data));
-}, []);
+type CourseListItem = {
+  id: number;
+  title: string;
+  description?: string | null;
+  progress: number;
+  thumbnail?: string | null;
+};
 
+type Lesson = {
+  id: number;
+  title: string;
+  videoUrl: string;
+  order: number;
+};
+
+type CourseDetail = CourseListItem & {
+  lessons: Lesson[];
+};
+
+const COURSES_API_URL = "http://localhost:8000/courses";
+
+export default function CoursesSection({ theme }: CoursesSectionProps) {
+  const [courses, setCourses] = useState<CourseListItem[]>([]);
+  const [isListLoading, setIsListLoading] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [selectedCourse, setSelectedCourse] = useState<CourseDetail | null>(
+    null,
+  );
+  const [selectedLessonId, setSelectedLessonId] = useState<number | null>(
+    null,
+  );
+  const [isCourseLoading, setIsCourseLoading] = useState(false);
+  const [courseError, setCourseError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchCourses = async () => {
+      setIsListLoading(true);
+      setListError(null);
+
+      try {
+        const response = await fetch(COURSES_API_URL);
+        if (!response.ok) {
+          throw new Error("Не удалось загрузить список курсов");
+        }
+
+        const data: CourseListItem[] = await response.json();
+
+        if (!Array.isArray(data)) {
+          throw new Error("Некорректный ответ сервера");
+        }
+
+        if (isMounted) {
+          setCourses(data);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setListError(
+            error instanceof Error
+              ? error.message
+              : "Произошла неизвестная ошибка",
+          );
+        }
+      } finally {
+        if (isMounted) {
+          setIsListLoading(false);
+        }
+      }
+    };
+
+    fetchCourses();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setIsDialogOpen(open);
+    if (!open) {
+      setSelectedCourse(null);
+      setSelectedLessonId(null);
+      setCourseError(null);
+    }
+  };
+
+  const handleCourseClick = useCallback(async (courseId: number) => {
+    setIsDialogOpen(true);
+    setIsCourseLoading(true);
+    setCourseError(null);
+
+    try {
+      const response = await fetch(`${COURSES_API_URL}/${courseId}`);
+
+      if (!response.ok) {
+        throw new Error("Не удалось загрузить информацию о курсе");
+      }
+
+      const data = await response.json();
+
+      const normalizedLessons: Lesson[] = Array.isArray(data.lessons)
+        ? data.lessons
+            .map((lesson: any) => ({
+              id: Number(lesson.id),
+              title: lesson.title,
+              videoUrl: lesson.video_url,
+              order: Number(lesson.order ?? 0),
+            }))
+            .sort((a, b) => a.order - b.order)
+        : [];
+
+      const normalizedCourse: CourseDetail = {
+        id: Number(data.id),
+        title: data.title,
+        description: data.description ?? "",
+        progress: Number(data.progress ?? 0),
+        thumbnail: data.thumbnail ?? null,
+        lessons: normalizedLessons,
+      };
+
+      setSelectedCourse(normalizedCourse);
+      setSelectedLessonId(normalizedLessons[0]?.id ?? null);
+    } catch (error) {
+      setCourseError(
+        error instanceof Error
+          ? error.message
+          : "Произошла неизвестная ошибка",
+      );
+    } finally {
+      setIsCourseLoading(false);
+    }
+  }, []);
+
+  const activeLesson = useMemo(() => {
+    if (!selectedCourse || selectedLessonId === null) {
+      return null;
+    }
+
+    return (
+      selectedCourse.lessons.find((lesson) => lesson.id === selectedLessonId) ??
+      null
+    );
+  }, [selectedCourse, selectedLessonId]);
 
   return (
     <section>
       <h2 className="text-2xl font-bold mb-6">Мои курсы</h2>
-      <div className="grid md:grid-cols-3 gap-6">
+
+      {listError && (
+        <p className="mb-4 rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-600">
+          {listError}
+        </p>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-3">
         <AnimatePresence>
-          {courses.map((course, idx) => (
-            <motion.div
-              key={idx}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -20 }}
-              transition={{ duration: 0.4, delay: idx * 0.1 }}
-              whileHover={{
-                scale: 1.05,
-                boxShadow:
-                  theme === "dark"
-                    ? "0 0 20px rgba(255,0,0,0.4)"
-                    : "0 0 20px rgba(255,0,0,0.2)",
-              }}
-            >
-              <Card
-                className={`${
-                  theme === "dark"
-                    ? "bg-gray-900 border-red-800"
-                    : "bg-gray-100 border-gray-300"
-                } shadow-xl transition`}
-              >
-                <CardContent className="p-6">
-                  <h3 className="text-xl font-semibold mb-4">{course.title}</h3>
-                  <div className="w-full bg-gray-700 rounded-full h-3 mb-4">
-                    <div
-                      className={`${course.color} h-3 rounded-full`}
-                      style={{ width: `${course.progress}%` }}
-                    ></div>
-                  </div>
-                  <p className="text-sm opacity-70 mb-4">
-                    Прогресс: {course.progress}%
-                  </p>
-                  <Button className="bg-red-700 hover:bg-red-800 w-full">
-                    Продолжить
-                  </Button>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
+          {isListLoading
+            ? Array.from({ length: 3 }).map((_, idx) => (
+                <motion.div
+                  key={`skeleton-${idx}`}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4, delay: idx * 0.1 }}
+                >
+                  <Card
+                    className={`${
+                      theme === "dark"
+                        ? "bg-gray-900 border-gray-800"
+                        : "bg-gray-100 border-gray-200"
+                    } shadow-xl transition`}
+                  >
+                    <CardContent className="p-6 space-y-4">
+                      <Skeleton className="h-6 w-3/4" />
+                      <Skeleton className="h-32 w-full rounded-lg" />
+                      <Skeleton className="h-3 w-full" />
+                      <Skeleton className="h-9 w-full" />
+                    </CardContent>
+                  </Card>
+                </motion.div>
+              ))
+            : courses.map((course, idx) => (
+                <motion.div
+                  key={course.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -20 }}
+                  transition={{ duration: 0.4, delay: idx * 0.1 }}
+                  whileHover={{
+                    scale: 1.02,
+                    boxShadow:
+                      theme === "dark"
+                        ? "0 0 20px rgba(255,0,0,0.35)"
+                        : "0 0 20px rgba(255,0,0,0.2)",
+                  }}
+                >
+                  <Card
+                    className={`${
+                      theme === "dark"
+                        ? "bg-gray-900 border-red-800"
+                        : "bg-gray-100 border-gray-300"
+                    } shadow-xl transition`}
+                  >
+                    <CardContent className="p-6">
+                      <h3 className="text-xl font-semibold mb-3">
+                        {course.title}
+                      </h3>
+
+                      {course.thumbnail && (
+                        <div className="mb-4 overflow-hidden rounded-lg border border-white/10">
+                          <img
+                            src={course.thumbnail}
+                            alt="Обложка курса"
+                            className="h-32 w-full object-cover"
+                            loading="lazy"
+                          />
+                        </div>
+                      )}
+
+                      {course.description && (
+                        <p className="mb-4 text-sm text-muted-foreground">
+                          {course.description}
+                        </p>
+                      )}
+
+                      <div className="mb-4">
+                        <div className="w-full bg-gray-700/50 rounded-full h-3">
+                          <div
+                            className="h-3 rounded-full bg-red-600"
+                            style={{ width: `${course.progress}%` }}
+                          ></div>
+                        </div>
+                        <p className="mt-2 text-sm opacity-70">
+                          Прогресс: {course.progress}%
+                        </p>
+                      </div>
+
+                      <Button
+                        className="bg-red-700 hover:bg-red-800 w-full"
+                        onClick={() => handleCourseClick(course.id)}
+                      >
+                        Смотреть уроки
+                      </Button>
+                    </CardContent>
+                  </Card>
+                </motion.div>
+              ))}
         </AnimatePresence>
       </div>
+
+      {!isListLoading && !courses.length && !listError && (
+        <p className="mt-6 text-sm text-muted-foreground">
+          У вас пока нет активных курсов.
+        </p>
+      )}
+
+      <Dialog open={isDialogOpen} onOpenChange={handleDialogOpenChange}>
+        <DialogContent className="max-w-5xl">
+          <DialogHeader>
+            <DialogTitle>
+              {selectedCourse?.title ?? "Загрузка курса"}
+            </DialogTitle>
+            {selectedCourse?.description && (
+              <p className="text-sm text-muted-foreground">
+                {selectedCourse.description}
+              </p>
+            )}
+          </DialogHeader>
+
+          {isCourseLoading ? (
+            <div className="flex h-48 items-center justify-center">
+              <div className="h-12 w-12 animate-spin rounded-full border-4 border-muted border-t-red-600" />
+            </div>
+          ) : courseError ? (
+            <p className="text-sm text-red-600">{courseError}</p>
+          ) : selectedCourse ? (
+            <div className="grid gap-6 md:grid-cols-[2fr_1fr]">
+              <div>
+                <AspectRatio ratio={16 / 9} className="overflow-hidden rounded-xl bg-black">
+                  {activeLesson ? (
+                    <video
+                      key={`${selectedCourse.id}-${activeLesson.id}`}
+                      className="h-full w-full object-contain"
+                      controls
+                      preload="metadata"
+                      src={activeLesson.videoUrl}
+                    >
+                      Ваш браузер не поддерживает воспроизведение видео.
+                    </video>
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+                      Выберите урок, чтобы начать просмотр
+                    </div>
+                  )}
+                </AspectRatio>
+
+                {activeLesson && (
+                  <p className="mt-4 text-sm text-muted-foreground">
+                    Сейчас воспроизводится: {activeLesson.title}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold mb-3">Содержание курса</h3>
+                <ScrollArea className="h-[320px] pr-2">
+                  <div className="space-y-2">
+                    {selectedCourse.lessons.map((lesson) => (
+                      <button
+                        key={lesson.id}
+                        type="button"
+                        onClick={() => setSelectedLessonId(lesson.id)}
+                        className={cn(
+                          "w-full rounded-lg border p-3 text-left transition",
+                          lesson.id === selectedLessonId
+                            ? "border-red-600 bg-red-600/10 text-red-600"
+                            : "border-border hover:border-red-500/60"
+                        )}
+                      >
+                        <span className="block text-sm font-medium">
+                          {lesson.order}. {lesson.title}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Выберите курс, чтобы посмотреть его содержание.
+            </p>
+          )}
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add Course and Lesson models with seeded lesson data stored in the database
- expose course listing and detail endpoints that serve CDN video URLs for each lesson
- implement a dashboard dialog video player with lesson navigation for "Мои курсы"

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e0e6b6e08c833293e4ad72ad22d92e