### PR TITLE
Fix dark theme course card text color

### DIFF
--- a/src/pages/dashboard/sections/CoursesSection.tsx
+++ b/src/pages/dashboard/sections/CoursesSection.tsx
@@ -131,8 +131,8 @@ export default function CoursesSection({ theme }: CoursesSectionProps) {
                   <Card
                     className={`${
                       theme === "dark"
-                        ? "bg-gray-900 border-red-800"
-                        : "bg-gray-100 border-gray-300"
+                        ? "bg-gray-900 border-red-800 text-white"
+                        : "bg-gray-100 border-gray-300 text-gray-900"
                     } shadow-xl transition`}
                   >
                     <CardContent className="p-6">


### PR DESCRIPTION
## Summary
- ensure the course cards on the My Courses dashboard view apply theme-aware text colors so titles remain legible in dark mode

## Testing
- npm run lint *(fails: existing lint errors in unrelated UI component files)*

------
https://chatgpt.com/codex/tasks/task_b_68e2fe487d9483328e306108f3bec0a5